### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/stackpop/mocktioneer/security/code-scanning/4](https://github.com/stackpop/mocktioneer/security/code-scanning/4)

In general, you should explicitly specify a `permissions` block for workflows and/or jobs so that the GITHUB_TOKEN has only the scopes required. For pure CI/test jobs like these, `contents: read` is typically sufficient, since they only need to fetch the code and possibly read repository contents; artifact upload does not require additional repo permissions.

The best fix here is to define a workflow-level `permissions` block that applies to all jobs, since both `test` and `playwright` are test-only jobs with no write operations against the repository. Insert a `permissions:` mapping near the top of `.github/workflows/test.yml` (e.g., after the `on:` block) and set `contents: read`. This documents and enforces that the GITHUB_TOKEN cannot modify repository contents, issues, or pull requests when running these jobs, without altering the existing behavior of the steps.

Concretely:
- Edit `.github/workflows/test.yml`.
- Add:

```yaml
permissions:
  contents: read
```

after the `on:` section (lines 3–7) and before `concurrency:` (line 9). No other changes, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
