### PR TITLE
Fix reference to EdgeZero CLI in documentation

### DIFF
--- a/.cargo/config.toml.local
+++ b/.cargo/config.toml.local
@@ -4,7 +4,7 @@
 [net]
 git-fetch-with-cli = true
 
-[patch."git+ssh://git@github.com/stackpop/edgezero.git"]
+[patch."https://github.com/stackpop/edgezero.git"]
 edgezero-adapter-axum = { path = "../edgezero/crates/edgezero-adapter-axum" }
 edgezero-adapter-cloudflare = { path = "../edgezero/crates/edgezero-adapter-cloudflare" }
 edgezero-adapter-fastly = { path = "../edgezero/crates/edgezero-adapter-fastly" }

--- a/docs/guide/adapters/index.md
+++ b/docs/guide/adapters/index.md
@@ -73,7 +73,7 @@ The EdgeZero CLI provides a unified interface for all adapters. It's maintained 
 
 ```bash
 # Install (requires access to EdgeZero repo)
-cargo install --git ssh://git@github.com/stackpop/edgezero.git edgezero-cli --features cli
+cargo install --git https://github.com/stackpop/edgezero.git edgezero-cli --features cli
 
 # Serve any adapter
 edgezero-cli serve --adapter axum

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -29,7 +29,7 @@ The EdgeZero CLI provides a unified interface for all adapters, but it is mainta
 If you have access to the EdgeZero repo:
 
 ```bash
-cargo install --git ssh://git@github.com/stackpop/edgezero.git edgezero-cli --features cli
+cargo install --git https://github.com/stackpop/edgezero.git edgezero-cli --features cli
 ```
 
 Or run it from a local EdgeZero checkout:

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -10,8 +10,9 @@ npx playwright install
 ```
 
 **Note:** The Cloudflare adapter requires `edgezero-cli` (not `edgezero`):
+
 ```bash
-cargo install --git https://git@github.com/stackpop/edgezero.git edgezero-cli
+cargo install --git https://github.com/stackpop/edgezero.git edgezero-cli
 ```
 
 ## Running Tests
@@ -44,9 +45,9 @@ npx playwright show-report
 
 The `ADAPTER` environment variable controls which adapter is tested:
 
-| Value | Command | Description |
-|-------|---------|-------------|
-| `axum` (default) | `cargo run -p mocktioneer-adapter-axum` | Native Axum server |
-| `cloudflare` | `edgezero-cli serve --adapter cloudflare` | Cloudflare Workers (WASM) |
+| Value            | Command                                   | Description               |
+| ---------------- | ----------------------------------------- | ------------------------- |
+| `axum` (default) | `cargo run -p mocktioneer-adapter-axum`   | Native Axum server        |
+| `cloudflare`     | `edgezero-cli serve --adapter cloudflare` | Cloudflare Workers (WASM) |
 
 Both adapters run on `http://127.0.0.1:8787`.


### PR DESCRIPTION
## Summary

- Fix incorrect `ssh://git@github.com` and `git@github.com` URLs for the EdgeZero repo to use `https://github.com` across documentation and local cargo config
- Affected files: docs/guide/adapters/index.md, docs/guide/getting-started.md, tests/playwright/README.md, .cargo/config.toml.local
- Fix markdown table alignment in tests/playwright/README.md

## Test plan

- [x] Verify `cargo install --git https://github.com/stackpop/edgezero.git edgezero-cli --features cli` resolves correctly
- [x] Review rendered docs for correct formatting

Close #51 