### PR TITLE
Fix CLAUDE.md and pr-creator inconsistencies

### DIFF
--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -29,10 +29,11 @@ If any gate fails, report the failure and stop — do not create a broken PR.
 
 ### 3. Ensure a linked issue exists
 
-Every PR should close a ticket. If no issue exists for this work:
+Every PR should close a ticket.
 
-1. Create one using the appropriate issue type (see Issue Types below).
-2. Reference it in the PR body with `Closes #<number>`.
+1. Ask the user for the issue number to close, or whether to create a new one.
+2. If creating a new issue, use the appropriate issue type (see Issue Types below).
+3. Reference it in the PR body with `Closes #<number>`.
 
 ### 4. Draft PR content
 
@@ -47,7 +48,7 @@ Using the `.github/pull_request_template.md` structure, draft:
 ### 5. Create the PR
 
 ```
-gh pr create --title "<short title under 70 chars>" --body "$(cat <<'EOF'
+gh pr create --title "<short title under 70 chars>" --assignee @me --body "$(cat <<'EOF'
 <filled template>
 EOF
 )"
@@ -98,4 +99,5 @@ Do **not** use labels as a substitute for types.
 - If the branch has many commits, group related changes in the summary.
 - Never force-push or rebase without explicit user approval.
 - Always base PRs against `main` unless told otherwise.
+- Always assign the PR to the current user (`--assignee @me`).
 - Do **not** include any byline, "Generated with" footer, or `Co-Authored-By` trailer — in PR bodies or commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,8 +161,9 @@ Every PR must pass:
 1. `cargo fmt --all -- --check`
 2. `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 3. `cargo test --workspace --all-targets`
-4. Playwright e2e tests (`tests/playwright/`)
-5. ESLint + Prettier on `docs/`
+4. `cargo check --workspace --all-targets --features "fastly cloudflare"`
+5. Playwright e2e tests (`tests/playwright/`)
+6. ESLint + Prettier on `docs/`
 
 Docker image is built and pushed to `ghcr.io/stackpop/mocktioneer` on push to
 main and on releases.
@@ -317,3 +318,4 @@ Custom commands live in `.claude/commands/`:
 - Don't commit without running `cargo test` first.
 - Don't skip `cargo fmt` and `cargo clippy` — CI will reject the PR.
 - Don't introduce non-deterministic behavior (randomness, time-dependent logic).
+- Don't include `Co-Authored-By` trailers, "Generated with" footers, or any AI bylines in commits or PR bodies.


### PR DESCRIPTION
## Summary

- Fix inconsistencies between CLAUDE.md, pr-creator agent, and edgezero's equivalents
- Ensure CI Gates, byline rules, issue linking flow, and PR assignment are consistent across all config files

## Changes

| File | Change |
| --- | --- |
| `CLAUDE.md` | Add `cargo check --features` to CI Gates; add no-byline rule to "What NOT to Do" |
| `.claude/agents/pr-creator.md` | Step 3 asks user for issue number; add `--assignee @me` and matching rule |

Closes #61

## Test plan

- [x] Changes are documentation/config only — no code changes
- [x] Verified consistency with edgezero equivalents

## Checklist

- [x] Changes follow project conventions in `CLAUDE.md`
- [x] No code changes requiring `cargo test`