### PR TITLE
Add project board integration to agents

### DIFF
--- a/.claude/agents/issue-creator.md
+++ b/.claude/agents/issue-creator.md
@@ -52,7 +52,45 @@ Get the issue node ID with:
 gh issue view <number> --json id --jq '.id'
 ```
 
-### 5. Report
+### 5. Add to project board and set status
+
+Add the issue to the **Stackpop Development** project and set its status to
+"Ready". The `addProjectV2ItemById` mutation returns the project item ID needed
+for the status update.
+
+```
+ITEM_ID=$(gh api graphql -f query='mutation {
+  addProjectV2ItemById(input: {
+    projectId: "PVT_kwDOAAuvmc4BFjF5",
+    contentId: "<issue_node_id>"
+  }) { item { id } }
+}' --jq '.data.addProjectV2ItemById.item.id')
+```
+
+Then set status to "Ready":
+
+```
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwDOAAuvmc4BFjF5",
+    itemId: "'"$ITEM_ID"'",
+    fieldId: "PVTSSF_lADOAAuvmc4BFjF5zg22lrY",
+    value: { singleSelectOptionId: "61e4505c" }
+  }) { projectV2Item { id } }
+}'
+```
+
+Project board status IDs:
+
+| Status      | ID         |
+| ----------- | ---------- |
+| Backlog     | `f75ad846` |
+| Ready       | `61e4505c` |
+| In progress | `47fc9ee4` |
+| In review   | `df73e18b` |
+| Done        | `98236657` |
+
+### 6. Report
 
 Output the issue URL and type.
 

--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -63,7 +63,68 @@ EOF
 )"
 ```
 
-### 6. Report
+### 6. Update issue status
+
+After creating the PR, move the linked issue to "In progress" on the
+**Stackpop Development** project — unless it is already "In review".
+
+1. Get the issue's project item ID and current status:
+
+```
+gh api graphql -f query='query($issueId: ID!) {
+  node(id: $issueId) {
+    ... on Issue {
+      projectItems(first: 10) {
+        nodes {
+          id
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name optionId }
+          }
+        }
+      }
+    }
+  }
+}' -f issueId="<issue_node_id>"
+```
+
+2. If the current status is **not** "In review" (`df73e18b`), set it to
+   "In progress" (`47fc9ee4`):
+
+```
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwDOAAuvmc4BFjF5",
+    itemId: "<project_item_id>",
+    fieldId: "PVTSSF_lADOAAuvmc4BFjF5zg22lrY",
+    value: { singleSelectOptionId: "47fc9ee4" }
+  }) { projectV2Item { id } }
+}'
+```
+
+3. If the issue is not yet on the project, add it first:
+
+```
+gh api graphql -f query='mutation {
+  addProjectV2ItemById(input: {
+    projectId: "PVT_kwDOAAuvmc4BFjF5",
+    contentId: "<issue_node_id>"
+  }) { item { id } }
+}'
+```
+
+Then set the status as above.
+
+Project board status IDs:
+
+| Status      | ID         |
+| ----------- | ---------- |
+| Backlog     | `f75ad846` |
+| Ready       | `61e4505c` |
+| In progress | `47fc9ee4` |
+| In review   | `df73e18b` |
+| Done        | `98236657` |
+
+### 7. Report
 
 Output the PR URL and a summary of what was included.
 


### PR DESCRIPTION
## Summary

- Sync pr-creator and issue-creator with edgezero to include Stackpop Development project board integration
- pr-creator now moves linked issue to "In progress" after creating a PR
- issue-creator now adds new issues to the board with "Ready" status

## Changes

| File | Change |
| --- | --- |
| `.claude/agents/pr-creator.md` | Add Step 6: update issue status on project board after PR creation |
| `.claude/agents/issue-creator.md` | Add Step 5: add issue to project board and set "Ready" status |

Closes #61

## Test plan

- [x] Changes are documentation/config only — no code changes
- [x] Verified consistency with edgezero equivalents

## Checklist

- [x] Changes follow project conventions in `CLAUDE.md`
- [x] No code changes requiring `cargo test`