### PR TITLE
Fix pr-creator to move issue to In progress

### DIFF
--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -69,7 +69,7 @@ EOF
 )"
 ```
 
-### 6. Move linked issue to "In review"
+### 6. Move linked issue to "In progress"
 
 After creating the PR, move the linked issue on the project board — but only
 if it is **not** already in "In review" or "Done".
@@ -93,7 +93,7 @@ if it is **not** already in "In review" or "Done".
    }' -f issueId="$(gh issue view <number> --json id --jq '.id')"
    ```
 
-2. If current status is not "In review" or "Done", update it:
+2. If current status is not "In review" or "Done", set it to "In progress" (`47fc9ee4`):
 
    ```
    gh api graphql -f query='mutation {
@@ -101,7 +101,7 @@ if it is **not** already in "In review" or "Done".
        projectId: "PVT_kwDOAAuvmc4BFjF5"
        itemId: "<item_id>"
        fieldId: "PVTSSF_lADOAAuvmc4BFjF5zg22lrY"
-       value: { singleSelectOptionId: "df73e18b" }
+       value: { singleSelectOptionId: "47fc9ee4" }
      }) { projectV2Item { id } }
    }'
    ```


### PR DESCRIPTION
## Summary

- Fix pr-creator Step 6 to move linked issue to "In progress" instead of "In review" on PR creation, matching edgezero's behavior

## Changes

| File | Change |
| --- | --- |
| `.claude/agents/pr-creator.md` | Step 6: change target status from "In review" to "In progress" (`47fc9ee4`) |

Closes #64

## Test plan

- [x] Changes are documentation/config only — no code changes
- [x] Verified status option ID `47fc9ee4` matches "In progress" on project board

## Checklist

- [x] Changes follow project conventions in `CLAUDE.md`
- [x] No code changes requiring `cargo test`