### PR TITLE
Fix pr-reviewer to use PR Review heading

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -168,7 +168,7 @@ Include findings that cannot be pinpointed to a single line (cross-cutting
 concerns, architectural issues, dependency problems) in the review body:
 
 ```markdown
-## Staff Engineer Review
+## PR Review
 
 ### Summary
 


### PR DESCRIPTION
## Summary

- Rename the review body heading from "Staff Engineer Review" to "PR Review" in the pr-reviewer agent template

## Changes

| File | Change |
| --- | --- |
| `.claude/agents/pr-reviewer.md` | Review body heading: "Staff Engineer Review" → "PR Review" |

Closes #68

## Test plan

- [x] Changes are documentation/config only — no code changes

## Checklist

- [x] Changes follow project conventions in `CLAUDE.md`
- [x] No code changes requiring `cargo test`