### PR TITLE
chore: inherit crate metadata from workspace and move to Rust 2024 edition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ tests/playwright/                 # Playwright e2e tests (creative visibility, s
 - **Rust**: 1.95.0 (from `.tool-versions`)
 - **Node.js**: 24.12.0 (for docs site and Playwright tests)
 - **Fastly CLI**: v13.0.0
-- **Edition**: 2021
+- **Edition**: 2024
 - **Resolver**: 2
 - **License**: Apache-2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ members = [
 resolver = "2"
 
 [workspace.package]
+authors = ["Mocktioneer Team <dev@stackpop.dev>"]
+edition = "2024"
 license = "Apache-2.0"
+publish = false
+version = "0.1.0"
 
 [profile.release]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-authors = ["Mocktioneer Team <dev@stackpop.dev>"]
+authors = ["Mocktioneer Team <dev@stackpop.com>"]
 edition = "2024"
 license = "Apache-2.0"
 publish = false

--- a/crates/mocktioneer-adapter-axum/Cargo.toml
+++ b/crates/mocktioneer-adapter-axum/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "mocktioneer-adapter-axum"
-version = "0.1.0"
-edition = "2021"
-publish = false
-license.workspace = true
+description = "Native Axum HTTP server adapter for Mocktioneer."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [[bin]]
 name = "mocktioneer-adapter-axum"

--- a/crates/mocktioneer-adapter-cloudflare/Cargo.toml
+++ b/crates/mocktioneer-adapter-cloudflare/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "mocktioneer-adapter-cloudflare"
-version = "0.1.0"
-edition = "2021"
-publish = false
-license.workspace = true
+description = "Cloudflare Workers adapter for Mocktioneer (wasm32-unknown-unknown)."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [[bin]]
 name = "mocktioneer-adapter-cloudflare"

--- a/crates/mocktioneer-adapter-fastly/Cargo.toml
+++ b/crates/mocktioneer-adapter-fastly/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "mocktioneer-adapter-fastly"
-version = "0.1.0"
-edition = "2021"
-publish = false
-license.workspace = true
+description = "Fastly Compute adapter for Mocktioneer (wasm32-wasip1)."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [[bin]]
 name = "mocktioneer-adapter-fastly"

--- a/crates/mocktioneer-adapter-fastly/tests/contract.rs
+++ b/crates/mocktioneer-adapter-fastly/tests/contract.rs
@@ -5,8 +5,8 @@
 )]
 
 use edgezero_adapter_fastly::request::dispatch;
-use fastly::http::{Method as FastlyMethod, StatusCode as FastlyStatus};
 use fastly::Request as FastlyRequest;
+use fastly::http::{Method as FastlyMethod, StatusCode as FastlyStatus};
 use mocktioneer_core::build_app;
 
 fn fastly_request(method: FastlyMethod, path: &str) -> FastlyRequest {

--- a/crates/mocktioneer-adapter-spin/Cargo.toml
+++ b/crates/mocktioneer-adapter-spin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mocktioneer-adapter-spin"
-description = "Spin / Fermyon adapter for Mocktioneer (wasm32-wasip2)."
+description = "Spin / Fermyon adapter for Mocktioneer (wasm32-wasip1)."
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/mocktioneer-adapter-spin/Cargo.toml
+++ b/crates/mocktioneer-adapter-spin/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "mocktioneer-adapter-spin"
-version = "0.1.0"
-edition = "2021"
-publish = false
-license.workspace = true
+description = "Spin / Fermyon adapter for Mocktioneer (wasm32-wasip2)."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [[bin]]
 name = "mocktioneer-adapter-spin"

--- a/crates/mocktioneer-adapter-spin/tests/contract.rs
+++ b/crates/mocktioneer-adapter-spin/tests/contract.rs
@@ -10,7 +10,7 @@
 #![cfg(all(feature = "spin", target_arch = "wasm32"))]
 
 use edgezero_core::body::Body;
-use edgezero_core::http::{header, request_builder, Method, Request, Response, StatusCode};
+use edgezero_core::http::{Method, Request, Response, StatusCode, header, request_builder};
 use futures::executor::block_on;
 use mocktioneer_core::build_app;
 

--- a/crates/mocktioneer-core/Cargo.toml
+++ b/crates/mocktioneer-core/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "mocktioneer-core"
-version = "0.1.0"
-edition = "2021"
-publish = false
-license.workspace = true
+description = "Shared business logic for Mocktioneer: OpenRTB, APS, auction, render, and route handlers."
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/mocktioneer-core/src/auction.rs
+++ b/crates/mocktioneer-core/src/auction.rs
@@ -2,7 +2,7 @@ use crate::aps::{ApsBidRequest, ApsBidResponse, ApsContextual, ApsSlotResponse};
 use crate::openrtb::{
     Bid as OpenrtbBid, Imp as OpenrtbImp, MediaType, OpenRTBRequest, OpenRTBResponse, SeatBid,
 };
-use crate::render::{extract_ec_info, iframe_html, CreativeMetadata, SignatureStatus};
+use crate::render::{CreativeMetadata, SignatureStatus, extract_ec_info, iframe_html};
 use uuid::Uuid;
 
 // ============================================================================
@@ -59,12 +59,12 @@ pub fn size_from_imp(imp: &OpenrtbImp) -> (i64, i64) {
         if let (Some(width), Some(height)) = (banner.width, banner.height) {
             return (width, height);
         }
-        if let Some(fmt) = &banner.format {
-            if let Some(fmt0) = fmt.first() {
-                let width = fmt0.width;
-                let height = fmt0.height;
-                return (width, height);
-            }
+        if let Some(fmt) = &banner.format
+            && let Some(fmt0) = fmt.first()
+        {
+            let width = fmt0.width;
+            let height = fmt0.height;
+            return (width, height);
         }
     }
     (300, 250)
@@ -197,7 +197,7 @@ pub fn build_openrtb_response(
 /// Our mock uses transparent base64 encoding that CAN be decoded for testing/debugging purposes.
 /// Example: `echo "MC4y" | base64 -d` → `0.2`.
 fn encode_aps_price(price: f64) -> String {
-    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
 
     let price_str = price.to_string();
     STANDARD.encode(price_str.as_bytes())
@@ -210,7 +210,7 @@ fn encode_aps_price(price: f64) -> String {
 #[inline]
 #[must_use]
 pub fn decode_aps_price(encoded: &str) -> Option<f64> {
-    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
 
     let decoded = STANDARD.decode(encoded).ok()?;
     let price_str = String::from_utf8(decoded).ok()?;

--- a/crates/mocktioneer-core/src/mediation.rs
+++ b/crates/mocktioneer-core/src/mediation.rs
@@ -4,7 +4,7 @@
 //! and selects winners based on price (highest price wins).
 
 use crate::openrtb::{Bid as OpenRTBBid, Imp, MediaType, OpenRTBRequest, OpenRTBResponse, SeatBid};
-use crate::render::{extract_ec_info, iframe_html, CreativeMetadata, SignatureStatus};
+use crate::render::{CreativeMetadata, SignatureStatus, extract_ec_info, iframe_html};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;

--- a/crates/mocktioneer-core/src/routes.rs
+++ b/crates/mocktioneer-core/src/routes.rs
@@ -10,7 +10,7 @@ use edgezero_core::extractor::{
     ForwardedHost, FromRequest, Headers, ValidatedJson, ValidatedQuery,
 };
 use edgezero_core::http::{
-    header, response_builder, HeaderMap, HeaderValue, Method, Response, StatusCode,
+    HeaderMap, HeaderValue, Method, Response, StatusCode, header, response_builder,
 };
 use edgezero_core::middleware::{Middleware, Next};
 use edgezero_core::{body::Body, error::EdgeError};
@@ -23,10 +23,10 @@ use crate::aps::ApsBidRequest;
 use crate::auction::{
     build_aps_response, build_openrtb_response, is_standard_size, standard_sizes,
 };
-use crate::mediation::{mediate_auction, MediationRequest};
+use crate::mediation::{MediationRequest, mediate_auction};
 use crate::openrtb::OpenRTBRequest;
 use crate::render::{
-    creative_html, extract_ec_hash, info_html, render_svg, render_template_str, SignatureStatus,
+    SignatureStatus, creative_html, extract_ec_hash, info_html, render_svg, render_template_str,
 };
 use crate::verification::verify_request_id_signature;
 
@@ -273,10 +273,10 @@ fn apply_cors(headers: &mut HeaderMap) {
 
 fn build_response(status: StatusCode, body: Body) -> Response {
     let mut builder = response_builder().status(status);
-    if let Body::Once(bytes) = &body {
-        if !bytes.is_empty() {
-            builder = builder.header(header::CONTENT_LENGTH, bytes.len().to_string());
-        }
+    if let Body::Once(bytes) = &body
+        && !bytes.is_empty()
+    {
+        builder = builder.header(header::CONTENT_LENGTH, bytes.len().to_string());
     }
     builder.body(body).unwrap_or_else(|_| {
         response_builder()
@@ -391,10 +391,10 @@ pub async fn handle_static_creatives(
 fn parse_cookie<'cookie>(cookie_header: &'cookie str, name: &str) -> Option<&'cookie str> {
     for part in cookie_header.split(';') {
         let trimmed = part.trim();
-        if let Some((key, value)) = trimmed.split_once('=') {
-            if key.trim() == name {
-                return Some(value.trim());
-            }
+        if let Some((key, value)) = trimmed.split_once('=')
+            && key.trim() == name
+        {
+            return Some(value.trim());
         }
     }
     None
@@ -457,10 +457,10 @@ pub async fn handle_pixel(
         response_headers.insert(header::CONTENT_LENGTH, length_value);
     }
 
-    if let Some(cookie) = set_cookie {
-        if let Ok(value) = HeaderValue::from_str(&cookie) {
-            response.headers_mut().append("Set-Cookie", value);
-        }
+    if let Some(cookie) = set_cookie
+        && let Ok(value) = HeaderValue::from_str(&cookie)
+    {
+        response.headers_mut().append("Set-Cookie", value);
     }
 
     Ok(response)
@@ -756,10 +756,10 @@ pub async fn handle_sync_start(
         HeaderValue::from_static("no-store, no-cache, must-revalidate, max-age=0"),
     );
 
-    if let Some(cookie) = set_cookie {
-        if let Ok(value) = HeaderValue::from_str(&cookie) {
-            response.headers_mut().append("Set-Cookie", value);
-        }
+    if let Some(cookie) = set_cookie
+        && let Ok(value) = HeaderValue::from_str(&cookie)
+    {
+        response.headers_mut().append("Set-Cookie", value);
     }
 
     Ok(response)
@@ -998,7 +998,7 @@ mod tests {
     use edgezero_core::body::Body;
     use edgezero_core::context::RequestContext;
     use edgezero_core::error::EdgeError;
-    use edgezero_core::http::{request_builder, Method, Response, StatusCode};
+    use edgezero_core::http::{Method, Response, StatusCode, request_builder};
     use edgezero_core::params::PathParams;
     use edgezero_core::response::IntoResponse as _;
     use futures::executor::block_on;
@@ -1057,9 +1057,11 @@ mod tests {
             .unwrap();
         assert_eq!(ct, "image/gif");
         let cookies = response.headers().get_all("set-cookie");
-        assert!(cookies
-            .iter()
-            .any(|value| value.to_str().unwrap_or_default().starts_with("mtkid=")));
+        assert!(
+            cookies
+                .iter()
+                .any(|value| value.to_str().unwrap_or_default().starts_with("mtkid="))
+        );
     }
 
     #[test]

--- a/crates/mocktioneer-core/src/verification.rs
+++ b/crates/mocktioneer-core/src/verification.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use ed25519_dalek::{Signature, Verifier as _, VerifyingKey};
 use edgezero_core::body::Body;
 use edgezero_core::context::RequestContext;
@@ -635,9 +635,10 @@ mod tests {
         ));
         let err = result.unwrap_err();
         assert!(matches!(err, VerificationError::InvalidSignature(_)));
-        assert!(err
-            .to_string()
-            .contains("Missing ext.trusted_server.request_host"));
+        assert!(
+            err.to_string()
+                .contains("Missing ext.trusted_server.request_host")
+        );
     }
 
     #[test]
@@ -662,9 +663,10 @@ mod tests {
         ));
         let err = result.unwrap_err();
         assert!(matches!(err, VerificationError::InvalidSignature(_)));
-        assert!(err
-            .to_string()
-            .contains("Missing ext.trusted_server.request_scheme"));
+        assert!(
+            err.to_string()
+                .contains("Missing ext.trusted_server.request_scheme")
+        );
     }
 
     #[test]

--- a/crates/mocktioneer-core/tests/aps_endpoints.rs
+++ b/crates/mocktioneer-core/tests/aps_endpoints.rs
@@ -287,11 +287,13 @@ mod tests {
         assert_eq!(contextual.cfe, Some(true));
         assert_eq!(contextual.ev, Some(true));
         assert!(contextual.host.is_some());
-        assert!(contextual
-            .host
-            .as_ref()
-            .unwrap()
-            .contains("mocktioneer.test"));
+        assert!(
+            contextual
+                .host
+                .as_ref()
+                .unwrap()
+                .contains("mocktioneer.test")
+        );
         assert_eq!(contextual.cb, Some("6".to_owned()));
         assert_eq!(
             contextual.cfn,

--- a/crates/mocktioneer-core/tests/endpoints.rs
+++ b/crates/mocktioneer-core/tests/endpoints.rs
@@ -3,7 +3,7 @@ mod tests {
     use edgezero_core::app::App;
     use edgezero_core::body::Body;
     use edgezero_core::http::{
-        header, request_builder, HeaderValue, Method, Request, Response, StatusCode,
+        HeaderValue, Method, Request, Response, StatusCode, header, request_builder,
     };
     use futures::executor::block_on;
 


### PR DESCRIPTION
Closes #111

## What

Two related manifest changes, based directly on `main`.

**Crate metadata now lives in one place.** `[workspace.package]` gains `authors`, `edition`, `publish`, and `version` (it previously carried only `license`), and every crate inherits those five keys via `{ workspace = true }` instead of re-declaring `version`/`edition`/`publish` by hand. Each crate also gets a `description`, which none had before. Every `[package]` block now reads `name`, `description`, then the inherited keys, so a new crate has an obvious template to copy.

**Workspace moves from the 2021 to the 2024 edition.** Rust 1.95 is already pinned in `.tool-versions`, well past the 1.85 that stabilized the 2024 edition, so this is a one-line change in `[workspace.package]`.

## Source churn from the edition bump

The edition upgrade compiled with zero migration errors. The only source changes are mechanical and semantics-preserving — both applied by tooling, then reviewed by hand:

- The 2024 style edition re-sorts imports so uppercase names sort first, e.g. `use base64::{Engine as _, engine::general_purpose::STANDARD}`. Applied by `cargo fmt`.
- Let-chains are stable in 2024, so clippy's `collapsible_if` now fires on nested `if let` pairs in `auction.rs` and `routes.rs`. They become `if let ... && let ...`. Applied by `cargo clippy --fix`.

## Verification

All CI gates pass locally:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets` — 161 passed, 0 failed
- `cargo check --workspace --all-targets --features "fastly cloudflare"`

## Note

`mocktioneer-cli` does not exist on `main` yet — it arrives with #110 — so it is deliberately not part of this PR. Once #110 merges, that crate should adopt the same inherited-metadata block; it is a one-line follow-up on that branch.

`publish = false` is now inherited workspace-wide, matching what every crate already set individually. If `mocktioneer-core` is ever published to crates.io it will need an explicit per-crate override.
